### PR TITLE
set Grafana version to 8.3.5 - security release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   dashboard:
     env_file: ./influxdb/env.env
     hostname: dashboard
-    image: grafana/grafana:8.3.5
+    image: grafana/grafana:8.5.2
     environment:
       GF_SECURITY_ADMIN_USER: "admin"
       GF_SECURITY_ADMIN_PASSWORD: "admin"
@@ -35,7 +35,7 @@ services:
   telegraf:
     env_file: ./influxdb/env.env
     hostname: telegraf
-    image: telegraf:1.21.3
+    image: telegraf:1.22.3
     volumes:
       - ./telegraf/:/etc/telegraf
       - ./tls/:/etc/telegraf/mqtt
@@ -45,7 +45,7 @@ services:
   influxdb:
     env_file: ./influxdb/env.env
     hostname: influxdb
-    image: influxdb:2.1
+    image: influxdb:2.2.0
     volumes:
       - ./influxdb/data:/var/lib/influxdb
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   dashboard:
     env_file: ./influxdb/env.env
     hostname: dashboard
-    image: grafana/grafana:8.3.4
+    image: grafana/grafana:8.3.5
     environment:
       GF_SECURITY_ADMIN_USER: "admin"
       GF_SECURITY_ADMIN_PASSWORD: "admin"

--- a/grafana/conf/defaults.ini
+++ b/grafana/conf/defaults.ini
@@ -907,6 +907,19 @@ zipkin_propagation = false
 # Not disabling is the most common setting when using Zipkin elsewhere in your infrastructure.
 disable_shared_zipkin_spans = false
 
+[tracing.opentelemetry.jaeger]
+# jaeger destination (ex http://localhost:14268/api/traces)
+address =
+# Propagation specifies the text map propagation format: w3c, jaeger
+propagation =
+
+# This is a configuration for OTLP exporter with GRPC protocol
+[tracing.opentelemetry.otlp]
+# otlp destination (ex localhost:4317)
+address =
+# Propagation specifies the text map propagation format: w3c, jaeger
+propagation =
+
 #################################### External Image Storage ##############
 [external_image_storage]
 # Used for uploading images to public servers so they can be included in slack/email messages.


### PR DESCRIPTION
update Grafana version - https://grafana.com/blog/2022/02/08/grafana-7.5.15-and-8.3.5-released-with-moderate-severity-security-fixes/